### PR TITLE
0.0.6 - Use global_golr_server variable for GOLR. Don't trim auto fields. widen menu

### DIFF
--- a/app/inject.tmpl
+++ b/app/inject.tmpl
@@ -43,7 +43,7 @@
               aria-describedby="igGP"
               type="text"
               ng-model="tvc.editingModel.GP"
-              ng-trim="true"
+              ng-trim="false"
               ng-blur="noResultsGP = false"
               uib-typeahead="term as term.label for term in tvc.getTerm('GP', $viewValue)"
               typeahead-append-to-body="true"
@@ -86,7 +86,7 @@
               aria-describedby="ig{{term}}"
               type="text"
               ng-model="tvc.editingModel[term]"
-              ng-trim="true"
+              ng-trim="false"
               ng-blur="noResults[term] = false"
               uib-typeahead="term as term.label for term in tvc.getTerm(term, $viewValue)"
               typeahead-append-to-body="true"
@@ -127,7 +127,7 @@
               aria-describedby="ig{{term}}e"
               type="text"
               ng-model="tvc.editingModel[term + 'e']"
-              ng-trim="true"
+              ng-trim="false"
               ng-blur="noResults[term + 'e'] = false"
               uib-typeahead="term as term.label for term in tvc.getTerm(term + 'e', $viewValue)"
               typeahead-append-to-body="true"
@@ -256,10 +256,7 @@
 
   <script type="text/ng-template" id="customTemplate.html">
     <a>
-
-  <!--       <span style="display:inline-block;min-width:320px;width:320px;font-size:0.7em;font-style:bold;" ng-bind-html="match.model | json"></span>
-  -->
-      <span style="display:inline-block;width:150px;font-size:0.9em;font-style:italic;" ng-bind-html="match.model.id | uibTypeaheadHighlight:query"></span>
+      <span style="display:inline-block;width:200px;font-size:0.9em;font-style:italic;" ng-bind-html="match.model.id | uibTypeaheadHighlight:query"></span>
       <span ng-bind-html="match.model.label | uibTypeaheadHighlight:query"></span>
     </a>
   </script>

--- a/app/lookup.service.js
+++ b/app/lookup.service.js
@@ -11,7 +11,8 @@ export default class LookupService {
   }
 
   golrLookup(field, oldValue, val) {
-    var golrURLBase = 'http://amigo-dev-golr.berkeleybop.org/select';
+    /* global global_golr_server */
+    var golrURLBase = `${global_golr_server}/select`;
 
     var baseRequestParams = {
       defType: 'edismax',
@@ -31,18 +32,16 @@ export default class LookupService {
       _: Date.now()
     };
 
-    var requestParamsGP1 = Object.assign({}, baseRequestParams, {
-      q: val + '*',
-      'facet.field': 'category',
-      fq: 'document_category:"general"',
-      qf: [
-        'entity^3',
-        'entity_label_searchable^3',
-        'general_blob_searchable^3'
-      ],
-    });
-
-
+    // var requestParamsGP1 = Object.assign({}, baseRequestParams, {
+    //   q: val + '*',
+    //   'facet.field': 'category',
+    //   fq: 'document_category:"general"',
+    //   qf: [
+    //     'entity^3',
+    //     'entity_label_searchable^3',
+    //     'general_blob_searchable^3'
+    //   ],
+    // });
 
     var requestParamsGP = Object.assign({}, baseRequestParams, {
       q: val + '*',

--- a/workbenches/tableview-workbench/config.yaml
+++ b/workbenches/tableview-workbench/config.yaml
@@ -1,5 +1,5 @@
 menu-name: "Simple annoton editor"
-page-name: "Simple annoton editor v0.0.5"
+page-name: "Simple annoton editor v0.0.6"
 type: "model"
 help-link: "http://github.com/DoctorBud/tableview-workbench/issues"
 javascript:


### PR DESCRIPTION
0.0.6
- Use global_golr_server variable for GOLR.
-Don't trim autocomplete fields, so that terminating space can be used to select more effectively. 
- Widen the autocomplete popup menu.

