### PR TITLE
0.0.8 - Help for Save button. Remove store_model(). Allow non-F aspects. Bug fixes.

### DIFF
--- a/app/TVController.js
+++ b/app/TVController.js
@@ -199,18 +199,72 @@ export default class TVController {
       CC: null,
       CCe: null
     };
+
+    this.$timeout(() => {
+      const element = angular.element("#GPFocus");
+      element.focus()
+    });
   }
 
   saveRowEnabled() {
-    return  this.editingModel &&
-            this.editingModel.GP &&
-            this.editingModel.MF &&
-            this.editingModel.MFe;
+    let result = this.editingModel && this.editingModel.GP;
+    let reasons = [];
+
+    if (!result) {
+      reasons.push('A GP is required');
+    }
+    else {
+      let hasAtLeastOneElement = false;
+
+      if (result && this.editingModel.MF) {
+        if (!this.editingModel.MFe) {
+          result = false;
+          reasons.push('Missing MFe');
+        }
+        else {
+          hasAtLeastOneElement = true;
+        }
+      }
+
+
+      if (result && this.editingModel.BP) {
+        if (!this.editingModel.BPe) {
+          result = false;
+          reasons.push('Missing BPe');
+        }
+        else {
+          hasAtLeastOneElement = true;
+        }
+      }
+
+      if (result && this.editingModel.CC) {
+        if (!this.editingModel.CCe) {
+          result = false;
+          reasons.push('Missing CCe');
+        }
+        else {
+          hasAtLeastOneElement = true;
+        }
+      }
+
+      if (!hasAtLeastOneElement) {
+        result = false;
+        reasons.push('At least one Aspect required.');
+      }
+    }
+
+    // console.log('saveRowEnabled', this.editingModel, result);
+    return {
+      result: result,
+      reasons: reasons
+    }
   }
+
 
   saveRow() {
     this.graph.saveEditingModel(this.editingModel);
   }
+
 
   editRow(row) {
     this.clearForm();
@@ -254,6 +308,8 @@ export default class TVController {
         };
       }
     }
+
+    // console.log('row.original', row.original, annoton);
     this.loadEditingModel(annoton);
   }
 

--- a/app/entry.js
+++ b/app/entry.js
@@ -3,7 +3,7 @@
 // Main program
 // Root of all the imports/requires
 
-window.tableviewWorkbenchVersion = '0.0.7';
+window.tableviewWorkbenchVersion = '0.0.8';
 
 import angular from 'angular';
 import 'angular-ui-grid/ui-grid.min.js';

--- a/app/inject.tmpl
+++ b/app/inject.tmpl
@@ -40,6 +40,7 @@
               <i class="fa fa-spinner fa-spin fa-fw"></i>
             </div>
             <input
+              id="GPFocus"
               aria-describedby="igGP"
               type="text"
               ng-model="tvc.editingModel.GP"
@@ -157,6 +158,7 @@
         <div class="input-group input-group-sm">
           <span class="input-group-addon" id="ig{{term}}eReference">Reference</span>
           <input
+            ng-disabled="!tvc.editingModel[term + 'e']"
             ng-model="tvc.editingModel[term + 'e'].reference"
             type="text"
             class="form-control"
@@ -169,6 +171,7 @@
         <div class="input-group input-group-sm">
           <span class="input-group-addon" id="ig{{term}}eWith">With</span>
           <input
+            ng-disabled="!tvc.editingModel[term + 'e']"
             ng-model="tvc.editingModel[term + 'e'].with"
             type="text"
             class="form-control"
@@ -186,11 +189,21 @@
       <div class="col-xs-12">
         <button
           type="button"
-          ng-disabled="!tvc.saveRowEnabled()"
+          ng-disabled="!tvc.saveRowEnabled().result"
           ng-click="tvc.saveRow()"
           class="btn btn-primary btn-sm center-block xbtn-block">
           Save Annoton
         </button>
+      </div>
+    </div>
+
+    <div
+      ng-if="!tvc.saveRowEnabled().result"
+      class="row">
+      <div class="col-xs-12">
+        <h6 ng-repeat="reason in tvc.saveRowEnabled().reasons" style="color:red;">
+          {{reason}}
+        </h6>
       </div>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tableview-workbench",
-  "version": "0.0.2",
+  "version": "0.0.8",
   "description": "A Noctua workbench (type='model') enabling viewing and editing models in a tabular format",
   "main": "index.js",
   "scripts": {

--- a/workbenches/tableview-workbench/config.yaml
+++ b/workbenches/tableview-workbench/config.yaml
@@ -1,5 +1,5 @@
 menu-name: "Simple annoton editor"
-page-name: "Simple annoton editor v0.0.7"
+page-name: "Simple annoton editor v0.0.8"
 type: "model"
 help-link: "http://github.com/DoctorBud/tableview-workbench/issues"
 javascript:


### PR DESCRIPTION
0.0.8
- Adds better enforcement and textual justification to the Save button's enablement
- Requires at least one Aspect, although if F is not specified, a root-level MF and associated ECO code will be synthesized to ensure a valid Annoton
- Removes use of store_model()
- Disables Ref/With if no evidence has been selected
- Sets focus to GP on a new form. Various bug fixes.